### PR TITLE
 Make #after_response return `current_response`

### DIFF
--- a/lib/hypernova/plugin/server_stacktrace.rb
+++ b/lib/hypernova/plugin/server_stacktrace.rb
@@ -10,10 +10,12 @@ module Hypernova
       end
 
       def after_response(current_response, _original_response)
-        current_response
-          .map { |name, result| [name, result.dig("error", "stack")] }
-          .select { |_, stack_trace| stack_trace }
-          .each { |name, stack_trace| log(name, stack_trace) }
+        current_response.tap do |hash|
+          hash
+            .map { |name, result| [name, result.dig("error", "stack")] }
+            .select { |_, stack_trace| stack_trace }
+            .each { |name, stack_trace| log(name, stack_trace) }
+        end
       end
 
       private

--- a/spec/hypernova/plugin/server_stacktrace_spec.rb
+++ b/spec/hypernova/plugin/server_stacktrace_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe Hypernova::Plugin::ServerStacktrace do
   let(:logger) { spy(:logger) }
 
   describe "#after_response" do
+    let(:described_method) { ->{ plugin.after_response(JSON.parse(fixture), double(:ignored)) } }
+    let(:fixture) { File.read(File.expand_path("../../fixtures/response.json", __dir__)) }
+
+    describe "return value" do
+      subject { described_method.call }
+      it { is_expected.to eq JSON.parse(fixture) }
+    end
+
     describe "logger" do
       subject { logger }
 
@@ -21,13 +29,10 @@ RSpec.describe Hypernova::Plugin::ServerStacktrace do
       end
 
       before do
-        response_fixture = File.read(File.expand_path("../../fixtures/response.json", __dir__))
-        current_response = JSON.parse(response_fixture)
-
-        plugin.after_response(current_response, double(:original_response))
+        described_method.call
       end
 
-      it { is_expected.to have_received(:error).with(expected_output) }
+      it { is_expected.to have_received(:error).once.with(expected_output) }
     end
   end
 end


### PR DESCRIPTION
As you can see [the document of hypernova-ruby](https://github.com/airbnb/hypernova-ruby#example), it expects `after_response` of the plugins to return the hash having the same form as `current_response` (passed as the first argument).
However, `ServerStacktrace#after_response` doesn't do that. This PR deal with it.